### PR TITLE
Refactor to use configurable data path via `DATA_PATH` environment variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	SpotifyRedirectUri  string `env:"SPOTIFY_CLIENT_REDIRECT_URI, default=http://localhost:28542/callback"`
 	TidalClientId       string `env:"TIDAL_CLIENT_ID, required"`
 	TidalClientSecret   string `env:"TIDAL_CLIENT_SECRET, required"`
+	DataPath            string `env:"DATA_PATH, default=/data"`
 }
 
 func Init() (*Config, error) {

--- a/convert/spotify_tidal.go
+++ b/convert/spotify_tidal.go
@@ -215,7 +215,7 @@ func (s *Service) SpotifyToTidal(ctx context.Context, saveMissingTracks bool, sa
 			err := spotify.WriteMissingTracks(fmt.Sprintf("%s", spotifyPlaylist.ID), spotify.MissingTracks{
 				Playlist: spotifyPlaylist,
 				Tracks:   missingTracks,
-			})
+			}, *s.SpotifyService.EnvConfig)
 			if err != nil {
 				return err
 			}
@@ -234,7 +234,7 @@ func (s *Service) SpotifyToTidal(ctx context.Context, saveMissingTracks bool, sa
 			for _, tidalTrack := range tPlaylistTracks.Items {
 				tPlaylist.Tracks = append(tPlaylist.Tracks, tidalTrack)
 			}
-			err = tidal.WriteTidalPlaylist(fmt.Sprintf("%s", tPlaylist.UUID), tPlaylist)
+			err = tidal.WriteTidalPlaylist(fmt.Sprintf("%s", tPlaylist.UUID), tPlaylist, *s.SpotifyService.EnvConfig)
 			if err != nil {
 				return err
 			}
@@ -272,7 +272,7 @@ func (s *Service) SpotifyToTidal(ctx context.Context, saveMissingTracks bool, sa
 				})
 			}
 
-			err = navidrome.WriteNavidromePlaylist(fmt.Sprintf("%s", tPlaylist.UUID), navidromePlaylist)
+			err = navidrome.WriteNavidromePlaylist(fmt.Sprintf("%s", tPlaylist.UUID), navidromePlaylist, s.SpotifyService.EnvConfig)
 			if err != nil {
 				return err
 			}

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func initialize() (*config.Config, *config.JsonConfigService, *spotify.Service, 
 	}
 
 	// database
-	dbConn, err := sql.Open("sqlite3", "/data/tracks.db")
+	dbConn, err := sql.Open("sqlite3", c.DataPath+"/tracks.db")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to open database")
 	}
@@ -45,14 +45,14 @@ func initialize() (*config.Config, *config.JsonConfigService, *spotify.Service, 
 	queries := db.New(dbConn)
 
 	// load json config which has credentials
-	jsonConfig := config.NewJsonConfigService("/data/config.json")
+	jsonConfig := config.NewJsonConfigService(c.DataPath + "/config.json")
 	err = jsonConfig.Init()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to load Spotify config")
 	}
 
 	// initialize the spotify connection
-	spotifyService, err := spotify.Initialize(c.SpotifyClientId, c.SpotifyClientSecret, c.SpotifyRedirectUri, jsonConfig)
+	spotifyService, err := spotify.Initialize(c.SpotifyClientId, c.SpotifyClientSecret, c.SpotifyRedirectUri, jsonConfig, c)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize Spotify service")
 	}

--- a/navidrome/navidrome.go
+++ b/navidrome/navidrome.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/zibbp/spotify-playlist-sync/config"
 )
 
 type Playlist struct {
@@ -23,13 +25,13 @@ type Track struct {
 	ISRC     string `json:"isrc"`
 }
 
-func WriteNavidromePlaylist(filename string, playlist interface{}) error {
-	if err := os.MkdirAll("/data/navidrome", 0755); err != nil {
+func WriteNavidromePlaylist(filename string, playlist interface{}, config *config.Config) error {
+	if err := os.MkdirAll(config.DataPath+"/navidrome", 0755); err != nil {
 		return err
 	}
 	json, err := json.Marshal(playlist)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(fmt.Sprintf("/data/navidrome/%s.json", filename), json, 0644)
+	return os.WriteFile(fmt.Sprintf(config.DataPath+"/navidrome/%s.json", filename), json, 0644)
 }

--- a/spotify/spotify.go
+++ b/spotify/spotify.go
@@ -11,17 +11,19 @@ import (
 type Service struct {
 	client            *spotifyPkg.Client
 	config            *config.JsonConfigService
+	EnvConfig         *config.Config
 	clientId          string
 	clientSecret      string
 	clientRedirectUri string
 }
 
-func Initialize(clientId, clientSecret, clientRedirectUri string, config *config.JsonConfigService) (*Service, error) {
+func Initialize(clientId, clientSecret, clientRedirectUri string, config *config.JsonConfigService, envConfig *config.Config) (*Service, error) {
 	var s Service
 	s.clientId = clientId
 	s.clientSecret = clientSecret
 	s.clientRedirectUri = clientRedirectUri
 	s.config = config
+	s.EnvConfig = envConfig
 
 	return &s, nil
 }

--- a/spotify/utils.go
+++ b/spotify/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/zibbp/spotify-playlist-sync/config"
 	libSpotify "github.com/zmb3/spotify/v2"
 )
 
@@ -14,13 +15,13 @@ type MissingTracks struct {
 }
 
 // WriteMissingTracks writes missing tracks Spotify playlist tracks to disk
-func WriteMissingTracks(filename string, missingTracks MissingTracks) error {
-	if err := os.MkdirAll("/data/missing", 0755); err != nil {
+func WriteMissingTracks(filename string, missingTracks MissingTracks, config config.Config) error {
+	if err := os.MkdirAll(config.DataPath+"/missing", 0755); err != nil {
 		return err
 	}
 	json, err := json.Marshal(missingTracks)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(fmt.Sprintf("/data/missing/%s.json", filename), json, 0644)
+	return os.WriteFile(fmt.Sprintf(config.DataPath+"/missing/%s.json", filename), json, 0644)
 }

--- a/tidal/utils.go
+++ b/tidal/utils.go
@@ -7,18 +7,20 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/zibbp/spotify-playlist-sync/config"
 )
 
 // WriteTidalPlaylist writes Tidal playlist to disk
-func WriteTidalPlaylist(filename string, playlist *Playlist) error {
-	if err := os.MkdirAll("/data/tidal", 0755); err != nil {
+func WriteTidalPlaylist(filename string, playlist *Playlist, config config.Config) error {
+	if err := os.MkdirAll(config.DataPath+"/tidal", 0755); err != nil {
 		return err
 	}
 	json, err := json.Marshal(playlist)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(fmt.Sprintf("/data/tidal/%s.json", filename), json, 0644)
+	return os.WriteFile(fmt.Sprintf(config.DataPath+"/tidal/%s.json", filename), json, 0644)
 }
 
 // parseISODuration converts an ISO 8601 duration (e.g., "P30M5S") to time.Duration


### PR DESCRIPTION
Adds a DATA_PATH environment variable

 - currently it is passed via SpotifyService to avoid to many changes to the rest of the logic