### PR TITLE
Update copyright field type to interface{} in search and tracks OpenA…

### DIFF
--- a/tidal/search/openapi_search.gen.go
+++ b/tidal/search/openapi_search.gen.go
@@ -73,7 +73,7 @@ type AlbumsAttributes struct {
 	BarcodeId string `json:"barcodeId"`
 
 	// Copyright Copyright information
-	Copyright *string `json:"copyright,omitempty"`
+	Copyright interface{} `json:"copyright,omitempty"`
 
 	// Duration Duration (ISO-8601)
 	Duration string `json:"duration"`
@@ -577,7 +577,7 @@ type TracksAttributes struct {
 	Availability *[]TracksAttributesAvailability `json:"availability,omitempty"`
 
 	// Copyright Copyright information
-	Copyright *string `json:"copyright,omitempty"`
+	Copyright interface{} `json:"copyright,omitempty"`
 
 	// Duration Duration expressed in accordance with ISO 8601
 	Duration string `json:"duration"`
@@ -644,7 +644,7 @@ type VideosAttributes struct {
 	Availability *[]VideosAttributesAvailability `json:"availability,omitempty"`
 
 	// Copyright Copyright information
-	Copyright *string `json:"copyright,omitempty"`
+	Copyright interface{} `json:"copyright,omitempty"`
 
 	// Duration Duration expressed in accordance with ISO 8601
 	Duration string `json:"duration"`

--- a/tidal/tracks/openapi_tracks.gen.go
+++ b/tidal/tracks/openapi_tracks.gen.go
@@ -84,7 +84,7 @@ type AlbumsAttributes struct {
 	BarcodeId string `json:"barcodeId"`
 
 	// Copyright Copyright information
-	Copyright *string `json:"copyright,omitempty"`
+	Copyright interface{} `json:"copyright,omitempty"`
 
 	// Duration Duration (ISO-8601)
 	Duration string `json:"duration"`
@@ -645,7 +645,7 @@ type TracksAttributes struct {
 	Availability *[]TracksAttributesAvailability `json:"availability,omitempty"`
 
 	// Copyright Copyright information
-	Copyright *string `json:"copyright,omitempty"`
+	Copyright interface{} `json:"copyright,omitempty"`
 
 	// Duration Duration expressed in accordance with ISO 8601
 	Duration string `json:"duration"`
@@ -754,7 +754,7 @@ type VideosAttributes struct {
 	Availability *[]VideosAttributesAvailability `json:"availability,omitempty"`
 
 	// Copyright Copyright information
-	Copyright *string `json:"copyright,omitempty"`
+	Copyright interface{} `json:"copyright,omitempty"`
 
 	// Duration Duration expressed in accordance with ISO 8601
 	Duration string `json:"duration"`


### PR DESCRIPTION
## Description

While syncing tracks, the application fails to match some Spotify tracks with Tidal due to a JSON unmarshal error:

```text
2:27AM ERR failed to find track on Tidal error="json: cannot unmarshal object into Go struct field TracksAttributes.data.attributes.copyright of type string" spotify_track_id=56sk7jBpZV0CD31G9hEU3b spotify_track_isrc=USJI10600117 spotify_track_name="Animal I Have Become"
2:27AM ERR failed to find track on Tidal error="json: cannot unmarshal object into Go struct field TracksAttributes.data.attributes.copyright of type string" spotify_track_id=3K4HG9evC7dg3N0R9cYqk4 spotify_track_isrc=USWB10002399 spotify_track_name="One Step Closer"
2:27AM ERR failed to find track on Tidal error="json: cannot unmarshal object into Go struct field TracksAttributes.data.attributes.copyright of type string" spotify_track_id=6RJdYpFQwLyNfDc5FbjkgV spotify_track_isrc=USRE10500766 spotify_track_name=Stricken
2:27AM ERR failed to find track on Tidal error="json: cannot unmarshal object into Go struct field TracksAttributes.data.attributes.copyright of type string" spotify_track_id=0jY829pCMnstlNtaE72vSB spotify_track_isrc=USRE10501019 spotify_track_name=Decadence
```
This happens because the copyright field returned by Tidal is not always a string — in some cases, it is an object.

## Fix

This PR updates the Copyright field type from *string to interface{} to allow proper unmarshalling regardless of the response format.

## Notes

The copyright field is currently not used anywhere in the codebase.

This change only prevents the unmarshal error and does not affect existing behavior.

